### PR TITLE
Change submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "datasheet"]
 	path = datasheet
-	url = git@github.com:holiday-jp/holiday_jp.git
+	url = https://github.com/holiday-jp/holiday_jp.git


### PR DESCRIPTION
こんにちは。国賀と申します。いつも holiday-jp をありがたく使わせていただいています。

holiday-jp の go 版で少し気になったことがありましたので、pull request します。

github.com/holiday-jp/holiday_jp-go を使ったシステムを Jenkins から自動デプロイしようと
したところ、github.com からの pull に失敗しました。ssh の鍵が設定されていないことが原因
でしたので、鍵の設定をして解消しました。この submodule で使われているプロトコルが ssh の
代わりに https になっていると、よりうれしいです。

もしお作法が間違っていましたら、ご指摘いただけると幸いです。

ご検討のほど、よろしくお願いします。
