### PR TITLE
Fix Holiday.Date method error

### DIFF
--- a/holiday.go
+++ b/holiday.go
@@ -49,7 +49,7 @@ func New(t time.Time) (*Holiday, error) {
 
 // Date returns the day of the holiday.
 func (h *Holiday) Date() (*time.Time, error) {
-	t, err := time.Parse(time.RFC3339, (*h)["date"]+" 00:00:00 +0000 UTC")
+	t, err := time.Parse("2006-01-02", (*h)["date"])
 	if err != nil {
 		return nil, err
 	}

--- a/holiday_test.go
+++ b/holiday_test.go
@@ -186,3 +186,15 @@ func TestBetween(t *testing.T) {
 		}
 	}
 }
+
+func TestHolidayDate(t *testing.T) {
+	for key, h := range holidays {
+		date, err := h.Date()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := date.Format("2006-01-02"); got != key {
+			t.Fatalf("\nwant %s,\nbut  %s:", key, got)
+		}
+	}
+}


### PR DESCRIPTION
はじめまして。
`Holiday` 構造体の `Date` メソッドでパースエラーが発生していたため、以下の修正を行いました。
コントリビューティングにガイドラインなどございましたらご指摘ください。ご確認のほどよろしくお願いいたします。

## 修正内容

- `Holiday` 構造体の `Date` メソッドのエラーの修正
- `Holiday` 構造体の `Date` メソッドのテストの追加

## 検証方法

- https://play.golang.org/p/En_j_WgedMH にエラーのサンプルコードを用意しました。
